### PR TITLE
Wip

### DIFF
--- a/asyncscope.md
+++ b/asyncscope.md
@@ -470,22 +470,20 @@ When `nest()` returns an unassociated sender:
 
 ## `execution::async_scope`
 
-1. An async scope represents a means of keeping track of senders that have been associated with the scope.
+```cpp
+template <class Scope, class Sender>
+  concept async_scope =
+    // only senders can be nested within scopes
+    sender<Sender> &&
+    // a scope is anything that can nest senders within itself
+    requires(Scope&& scope, Sender&& snd) {
+      { nest(std::forward<Sender>(snd), std::forward<Scope>(scope)) } -> sender;
+    };
+```
 
-   ```cpp
-   template <class Scope, class Sender>
-     concept async_scope =
-       // only senders can be nested within scopes
-       sender<Sender> &&
-       // a scope is anything that can nest senders within itself
-       requires(Scope&& scope, Sender&& snd) {
-         { nest(std::forward<Sender>(snd), std::forward<Scope>(scope)) } -> sender;
-       };
-   ```
-
-## Lifetime
-
-The `counting_scope` keeps a counter of how many spawned _`async-function`_ s have not completed.
+As described above, an async scope is a a type that imlpements a bookkeeping policy for senders. The `nest()` algorithm
+is the means by which senders are submitted as the subjects of such a policy so any type that permits senders to be
+`nest()`ed with it satisfies the `async_scope` concept.
 
 ## `execution::spawn()`
 
@@ -600,6 +598,10 @@ for ( int i=0; i<10; i++)
     spawn(s, on(sched, other_work(i)));
 return on(sched, std::move(snd));
 ```
+
+## Lifetime
+
+The `counting_scope` keeps a counter of how many spawned _`async-function`_ s have not completed.
 
 Design considerations
 =====================

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -13,6 +13,8 @@ author:
     email: <lwh@fb.com>
   - name: Lucian Radu Teodorescu
     email: <lucteo@lucteo.ro>
+  - name: Ian Petersen
+    email: <ispeters@meta.com>
 toc: true
 ---
 
@@ -42,8 +44,8 @@ _`async-function`_ s spawned by the `counting_scope` have completed.
 ## Implementation experience
 
 The general concept of an async scope to manage work has been deployed broadly in Meta's folly [@asyncscopefolly] to
-safely launch awaitables in Folly's coro library [@corofolly] and in Facebook's libunifex library [@asyncscopeunifex]
-where it is designed to be used with the sender/receiver pattern.
+safely launch awaitables in Folly's coro library [@corofolly] and in Meta's libunifex library [@asyncscopeunifex] where
+it is designed to be used with the sender/receiver pattern.
 
 ## RAII and _`async-object`_
 
@@ -1003,20 +1005,20 @@ references:
     citation-label: asyncscopeunifex
     type: header
     title: "async_scope"
-    url: https://github.com/facebookexperimental/libunifex/blob/main/include/unifex/async_scope.hpp
-    company: Facebook, Inc
+    url: https://github.com/facebookexperimental/libunifex/blob/main/include/unifex/v2/async_scope.hpp
+    company: Meta Platforms, Inc
   - id: letvwthunifex
     citation-label: letvwthunifex
     type: documentation
     title: "let_value_with"
     url: https://github.com/facebookexperimental/libunifex/blob/main/doc/api_reference.md#let_value_withinvocable-state_factory-invocable-func---sender
-    company: Facebook, Inc
+    company: Meta Platforms, Inc
   - id: libunifex
     citation-label: libunifex
     type: repository
     title: "libunifex"
     url: https://github.com/facebookexperimental/libunifex/
-    company: Facebook, Inc
+    company: Meta Platforms, Inc
   - id: asyncscopestdexec
     citation-label: asyncscopestdexec
     type: repository

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -68,8 +68,10 @@ implementation of an earlier version of the _Sender/Receiver_ model proposed in 
 although experience with the v1 design led to the creation of [@asyncscopeunifexv2], which has a smaller interface and
 only one responsibility.
 
-Note to self: this seems like an opportunity to talk about progressively structuring concurrent C++ within Meta, but
-that needs legal clearance.
+TODO: we have some implementation experience to share regarding our efforts to progressively add structure to an
+existing library at Meta that needs legal review before it can be made public and the review won't be complete before
+the mailing deadline. We'll include the experience in another revision, which we expect to be ready before the Tokyo
+meeting.
 
 Motivation
 ==========

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -1,7 +1,6 @@
 ---
 title: "`async_scope` -- Creating scopes for non-sequential concurrency"
-subtitle: "Draft Proposal"
-document: D3149R0
+document: P3149R0
 date: today
 audience:
   - "SG1 Parallelism and Concurrency"
@@ -143,8 +142,9 @@ int main() {
         ex::sender auto snd = ex::transfer_just(my_pool.get_scheduler(), item) |
                               ex::then([&](work_item* item) { do_work(ctx, item); });
 
-        // start `snd` as before, but associate the spawned work with `scope` so that it can be
-        // awaited before destroying the resources referenced by the work (i.e. `my_pool` and `ctx`)
+        // start `snd` as before, but associate the spawned work with `scope` so that it can
+        // be awaited before destroying the resources referenced by the work (i.e. `my_pool`
+        // and `ctx`)
         ex::spawn(std::move(snd), scope); // NEW!
     }
 
@@ -174,7 +174,8 @@ int main() {
   // fire and forget
   ex::start_detached(std::move(snd));
 
-  // `ctx` is destroyed, perhaps before `snd` is done
+  // `ctx` is destroyed, perhaps before
+  // `snd` is done
 }
 ```
 
@@ -194,10 +195,12 @@ int main() {
   // fire, but don't forget
   ex::spawn(std::move(snd), scope);
 
-  // wait for all work nested within scope to finish
+  // wait for all work nested within scope
+  // to finish
   this_thread::sync_wait(scope.join());
 
-  // `ctx` is destroyed once nothing references it
+  // `ctx` is destroyed once nothing
+  // references it
 }
 ```
 
@@ -365,7 +368,9 @@ task<size_t> listener(int port, io_context& ctx, static_thread_pool& pool) {
         // Create work to handle the connection in the scope of `work_scope`
         conn_data data{std::move(conn), ctx, pool};
         ex::sender auto snd = ex::just(std::move(data)) |
-                              ex::let_value([](auto& data) { return handle_connection(data); });
+                              ex::let_value([](auto& data) {
+                                return handle_connection(data);
+                              });
         ex::spawn(scope, std::move(snd));
     }
 
@@ -430,7 +435,8 @@ using @@_future-sender-t_@@ = // @@_exposition-only_@@
 }
 
 template <sender Sender>
-auto nest(Sender&& snd, auto&& scope) noexcept(noexcept(scope.nest(std::forward<Sender>(snd)))
+auto nest(Sender&& snd, auto&& scope)
+    noexcept(noexcept(scope.nest(std::forward<Sender>(snd)))
     -> decltype(scope.nest(std::forward<Sender>(snd)));
 
 template <class Scope, class Sender>
@@ -468,8 +474,9 @@ struct counting_scope {
 
     [[nodiscard]] @@_join-sender_@@ join() noexcept;
 
-    // observers in the spirit of std::weak_ptr<T>::expired() and std::shared_ptr<T>::use_count();
-    // the values must be correct when computed but may be stale by the time they can be observed
+    // observers in the spirit of std::weak_ptr<T>::expired() and
+    // std::shared_ptr<T>::use_count(); the values must be correct
+    // when computed but may be stale by the time they can be observed
 
     [[nodiscard]] bool joined() const noexcept;
 
@@ -681,8 +688,9 @@ struct counting_scope {
 
     [[nodiscard]] @@_join-sender_@@ join() noexcept;
 
-    // observers in the spirit of std::weak_ptr<T>::expired() and std::shared_ptr<T>::use_count();
-    // the values must be correct when computed but may be stale by the time they can be observed
+    // observers in the spirit of std::weak_ptr<T>::expired() and
+    // std::shared_ptr<T>::use_count(); the values must be correct
+    // when computed but may be stale by the time they can be observed
 
     [[nodiscard]] bool joined() const noexcept;
 

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -1,20 +1,24 @@
 ---
 title: "`async_scope` -- Creating scopes for non-sequential concurrency"
 subtitle: "Draft Proposal"
-document: D2519R0
+document: D3149R0
 date: today
 audience:
   - "SG1 Parallelism and Concurrency"
   - "LEWG Library Evolution"
 author:
+  - name: Ian Petersen
+    email: <ispeters@meta.com>
+  - name: Ján Ondrušek
+    email: <ondrusek@meta.com>
+  - name: Jessica Wong
+    email: <jesswong@meta.com>
   - name: Kirk Shoop
     email: <kirk.shoop@gmail.com>
   - name: Lee Howes
     email: <lwh@fb.com>
   - name: Lucian Radu Teodorescu
     email: <lucteo@lucteo.ro>
-  - name: Ian Petersen
-    email: <ispeters@meta.com>
 toc: true
 ---
 

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -1357,7 +1357,7 @@ references:
     citation-label: "`unifex::v2::async_scope`"
     type: header
     title: "unifex::v2::async_scope"
-    url: https://github.com/facebookexperimental/libunifex/blob/main/include/unifex/v1/async_scope.hpp
+    url: https://github.com/facebookexperimental/libunifex/blob/main/include/unifex/v2/async_scope.hpp
     company: Meta Platforms, Inc
   - id: letvwthunifex
     citation-label: letvwthunifex

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -29,7 +29,7 @@ Introduction
 ============
 
 [@P2300R7] lays the groundwork for writing structured concurrent programs in C++ but it leaves three important scenarios
-unaddressed:
+under- or unaddressed:
 
  1. progressively structuring an existing, unstructured concurrent program;
  2. starting a dynamic number of parallel tasks without "losing track" of them; and
@@ -38,11 +38,15 @@ unaddressed:
 This paper describes the utilities needed to address the above scenarios within the following constraints:
 
  * _No detached work by default;_ as specified in P2300R7, the `start_detached` and `ensure_started` algorithms invite
-   users to start concurrent work with no built-in way to know when that work has finished. Such so-called "detached
-   work" is undesirable; without a way to know when detached work is done, it is difficult know when it is safe to
-   destroy any resources referred to by the work. Ad hoc solutions to this shutdown problem add unnecessary complexity
-   that can be avoided by ensuring all concurrent work is "attached".
- * ...
+   users to start concurrent work with no built-in way to know when that work has finished.
+   * Such so-called "detached work" is undesirable; without a way to know when detached work is done, it is difficult
+     know when it is safe to destroy any resources referred to by the work. Ad hoc solutions to this shutdown problem
+     add unnecessary complexity that can be avoided by ensuring all concurrent work is "attached".
+   * Experienced C++ programmers who "know" that async C++ "is just hard" also "know" that starting concurrent work
+     means starting detached work so it's useful as a teaching aid to remove the unnecessary option.
+ * _No dependencies besides [@P2300R7];_ it will be important for the success of [@P2300R7] that existing code bases
+   can migrate from unstructured concurrency to structured concurrency in an incremental way so tools for progressively
+   structuring code should not take on risk in the form of unnecessary dependencies.
 
 The proposed solution comes in five parts:
 
@@ -57,8 +61,11 @@ The proposed solution comes in five parts:
 The general concept of an async scope to manage work has been deployed broadly at Meta. Code written with Folly's
 coroutine library, [@follycoro], uses [@follyasyncscope] to safely launch awaitables. Most code written with Unifex, an
 implementation of an earlier version of the _Sender/Receiver_ model proposed in [@P2300R7], uses [@asyncscopeunifexv1],
-although experience with the v1 design led us to create [@asyncscopeunifexv2], which has a smaller interface and only
-one responsibility.
+although experience with the v1 design led to the creation of [@asyncscopeunifexv2], which has a smaller interface and
+only one responsibility.
+
+Note to self: this seems like an opportunity to talk about progressively structuring concurrent C++ within Meta, but
+that needs legal clearance.
 
 Motivation
 ==========

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -810,11 +810,50 @@ return on(sched, std::move(snd));
 
 ### `counting_scope::join()`
 
+```cpp
+struct @@_join-sender_@@; // @@_exposition-only_@@
+
+[[nodiscard]] @@_join-sender_@@ join() noexcept;
+```
+
 ### `counting_scope::joined()`
+
+```cpp
+[[nodiscard]] bool joined() const noexcept;
+```
+
+Returns `true` if the scope is in the joined state (i.e. a _`join-sender`_ returned from `join()` has been connected,
+started, and completed, which implies that the count of outstanding senders has dropped to zero).
+
+`joined()` returning `true` implies that `join_started()` will also return `true` and `use_count()` will return `0`.
+
+_Note:_ if `joined()` returns `true` then it will never again return `false` however, it's possible for a return of
+`false` to be stale by the time it is observed since another thread of execution may be racing to complete a waiting
+_`join-sender`_.
 
 ### `counting_scope::join_started()`
 
+```cpp
+[[nodiscard]] bool join_started() const noexcept;
+```
+
+Returns `true` if the scope is in the closed/joining state or the joined state (i.e. returns `true` if a _`join-sender`_
+has been connected and started) and `false` otherwise.
+
+_Note:_ if `join_started()` returns `true` then it will never again return `false` however, it's possible for a return
+of `false` to be stale by the time it is observed since another thread of execution may be racing to start a
+_`join-sender`_.
+
 ### `counting_scope::use_count()`
+
+```cpp
+[[nodiscard]] size_t use_count() const noexcept;
+```
+
+Returns the number of senders that have been associated with this scope that have not yet completed.
+
+_Note:_ it is likely that the return value is stale by the time it's observed since another thread of execution may be
+racing to nest a new sender or complete an old one.
 
 Design considerations
 =====================

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -264,28 +264,24 @@ int main() {
 ```
 
 ## Starting work nested within a framework
+
+TODO: the idea behind this example is a good one, but the example itself is incomplete.
+
 In this example we use the `counting_scope` within a class to start work when the object receives a message and to wait
 for that work to complete before closing. `my_window::start()` starts the sender using storage reserved in `my_window`
 for this purpose.
 ```c++
-using namespace std::execution;
+namespace ex = std::execution;
 
-// 
+// …
 class my_window {
-  //..
+  // …
 
-  // async-construction creates the 
-  // async-object members
-  system_context ctx;
-  counting_scope scope{};
-
-  scheduler auto sch{ctx.scheduler()};
-};
-class my_window_resource {
-  //..
+  ex::system_scheduler sch;
+  ex::counting_scope scope{};
 };
 
-sender auto some_work(int id);
+ex::sender auto some_work(int id);
 
 void my_window::onMyMessage(int i) {
   ex::spawn(this->scope, on(this->sch, some_work(i)));


### PR DESCRIPTION
Start editing the upstream draft to spec out my vision for a necessary-and-sufficient set of tools to address the following needs that are not yet met by P2300:
 1. progressively structuring an existing, unstructured concurrent program;
 2. starting a dynamic number of parallel tasks without "losing track" of them; and
 3. opting in to eager execution of sender-shaped work when appropriate.