### PR TITLE
Add counting_scope::close() and simple_counting_scope

### DIFF
--- a/asyncscope.md
+++ b/asyncscope.md
@@ -1317,7 +1317,9 @@ state, and causes all future calls to `nest()` to fail.
 
 Any call to `nest()` may throw an exception if copying or moving the input sender into the returned _`nest-sender`_
 throws an exception. `nest()` provides the Strong Exception Guarantee so the scope's state is left unchanged if an
-exception is thrown while constructing the returned _`nest-sender`_. Assuming `nest()` does not throw:
+exception is thrown while constructing the returned _`nest-sender`_.
+
+Assuming `nest()` does not throw:
 
 - While a scope is in the unused, open, or open-and-joining state, calls to `nest()` succeed by returning an "associated
   sender" (see below) and incrementing the scope's count of outstanding operations _before returning_.

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -1189,18 +1189,18 @@ sender auto let_with_async_scope(Callable&& callable)
     noexcept(std::is_nothrow_constructible_v<std::decay_t<Callable>, Callable>);
 ```
 
-## `execution::counting_scope`
+## `execution::simple_counting_scope`
 
 ```cpp
-struct counting_scope {
-    counting_scope() noexcept;
-    ~counting_scope();
+struct simple_counting_scope {
+    simple_counting_scope() noexcept;
+    ~simple_counting_scope();
 
-    // counting_scope is immovable and uncopyable
-    counting_scope(const counting_scope&) = delete;
-    counting_scope(counting_scope&&) = delete;
-    counting_scope& operator=(const counting_scope&) = delete;
-    counting_scope& operator=(counting_scope&&) = delete;
+    // simple_counting_scope is immovable and uncopyable
+    simple_counting_scope(const simple_counting_scope&) = delete;
+    simple_counting_scope(simple_counting_scope&&) = delete;
+    simple_counting_scope& operator=(const simple_counting_scope&) = delete;
+    simple_counting_scope& operator=(simple_counting_scope&&) = delete;
 
     template <sender S>
     struct @@_nest-sender_@@; // @@_exposition-only_@@
@@ -1211,14 +1211,16 @@ struct counting_scope {
           noexcept(std::is_nothrow_constructible_v<std::remove_cvref_t<S>, S>);
 
      private:
-      friend counting_scope;
+      friend simple_counting_scope;
 
-      token(counting_scope* s) noexcept;
+      token(simple_counting_scope* s) noexcept;
 
-      counting_scope* scope; // @@_exposition-only_@@
+      simple_counting_scope* scope; // @@_exposition-only_@@
     };
 
     token get_token() noexcept;
+
+    void close() noexcept;
 
     struct @@_join-sender_@@; // @@_exposition-only_@@
 
@@ -1226,115 +1228,153 @@ struct counting_scope {
 };
 ```
 
-A `counting_scope` goes through four states during its lifetime:
+A `simple_counting_scope` maintains a count of outstanding operations and goes through several states durings its
+lifetime:
 
-1. unused
-2. open
-3. closed/joining
-4. joined
+- unused
+- open
+- closed
+- open-and-joining
+- closed-and-joining
+- unused-and-closed
+- joined
+
+The following diagram illustrates the `simple_counting_scope`'s state machine:
+
+```plantuml
+@startuml
+state unused {
+}
+state open {
+}
+state closed {
+}
+state "open-and-joining" as open_and_joining {
+}
+state "closed-and-joining" as closed_and_joining {
+}
+state "unused-and-closed" as unused_and_closed {
+}
+state joined {
+}
+
+unused : count = 0
+unused : nest() can succeed
+open : count ≥ 0
+open : nest() can succeed
+closed : count ≥ 0
+closed : nest() fails
+open_and_joining : count ≥ 0
+open_and_joining : nest() can succeed
+closed_and_joining : count ≥ 0
+closed_and_joining : nest() fails
+unused_and_closed : count = 0
+unused_and_closed : nest() fails
+joined : count = 0
+joined : nest() fails
+
+[*] --> unused
+unused --> open : nest()
+unused --> unused_and_closed : close()
+unused --> open_and_joining : join-sender\nstarted
+open --> closed : close()
+open --> open_and_joining : join-sender\nstarted
+closed --> closed_and_joining : join-sender\nstarted
+open_and_joining --> closed_and_joining : close()
+unused_and_closed --> closed_and_joining : join-sender\nstarted
+closed_and_joining --> joined : count reaches 0\njoin-sender completes
+open_and_joining --> joined : count reaches 0\njoin-sender completes
+joined --> [*] : \~simple_counting_scope()
+unused_and_closed --> [*] : \~simple_counting_scope()
+unused --> [*] : \~simple_counting_scope()
+
+@enduml
+```
+
+_Note: a scope is "open" if its current state is unused, open, or open-and-joining; a scope is "closed" if its current
+state is closed, unused-and-closed, closed-and-joining, or joined._
 
 Instances start in the unused state after being constructed. This is the only time the scope's state can be set to
-unused. Connecting and starting a _`join-sender`_ returned from `join()` transitions the scope to the closed/joining
-state. Merely calling `join()` or connecting the _`join-sender`_ does not change the scope's state---the
-_`operation-state`_ must be started to close the scope. The scope transitions from the closed/joining state to the
-joined state when the _`join-sender`_ completes. A scope must be in the joined or unused state when its destructor
-starts; otherwise, the destructor invokes `std::terminate()`. Permitting destruction in the unused state ensures that
-`counting_scope` can be used safely as a data-member type while preserving structured functionality.
+unused. When the `simple_counting_scope` destructor starts, the scope must be in the unused, unused-and-closed, or
+joined state; otherwise, the destructor invokes `std::terminate()`. Permitting destruction when the scope is in the
+unused or unused-and-closed state ensures that instances of `simple_counting_scope` can be used safely as data-members
+while preserving structured functionality.
 
-While a scope is unused or open, calls to `nest(snd, scope.get_token())` will succeed (unless an exception is thrown by
-`snd`'s copy- or move-constructor while constructing the _`nest-sender`_). Each time a call to
-`nest(snd, scope.get_token())` succeeds, three things happen:
+Connecting and starting a _`join-sender`_ returned from `join()` moves the scope to either the open-and-joining or
+closed-and-joining state. Merely calling `join()` or connecting the _`join-sender`_ does not change the scope's
+state---the _`operation-state`_ must be started to effect the state change. A started _`join-sender`_ completes when the
+scope's count of outstanding operations reaches zero, at which point the scope transitions to the joined state.
 
-1. if the scope was in the unused state then it transitions to the open state,
-2. the scope's count of outstanding senders is incremented before `nest()` returns, and
-3. the given sender, `snd`, is wrapped in a _`nest-sender`_ and returned.
+Calling `close()` on a `simple_counting_scope` moves the scope to the closed, unused-and-closed, or closed-and-joining
+state, and causes all future calls to `nest()` to fail.
 
-When a call to `nest()` succeeds, the returned _`nest-sender`_ is an associated sender that acts like an RAII handle:
-the scope's internal count is incremented when the sender is created and decremented when the sender is "done with the
-scope", which happens when the sender is destroyed, its _`operation-state`_ is destroyed, or its _`operation-state`_ is
-completed. Moving a _`nest-sender`_ transfers responsibility for decrementing the count from the old instance to the new
-one. Copying a _`nest-sender`_ is permitted if the sender it's wrapping is copyable, but the copy may "fail" since
-copying requires incrementing the scope's count, which is only allowed when the scope is open; if copying fails, the new
-sender is an unassociated sender that behaves as if it were the result of a failed call to `nest()`.
+Any call to `nest()` may throw an exception if copying or moving the input sender into the returned _`nest-sender`_
+throws an exception. `nest()` provides the Strong Exception Guarantee so the scope's state is left unchanged if an
+exception is thrown while constructing the returned _`nest-sender`_. Assuming `nest()` does not throw:
 
-If `nest()` is invoked on a token whose scope is in the unused state and `nest()` fails by throwing an exception, the
-scope remains in the unused state as part of providing the Strong Exception Guarantee.
+- While a scope is in the unused, open, or open-and-joining state, calls to `nest()` succeed by returning an "associated
+  sender" (see below) and incrementing the scope's count of outstanding operations _before returning_.
+- While a scope is in the closed, unused-and-closed, closed-and-joining, or joined state, calls to `nest()` fail by
+  returning an "unassociated sender" (see below). Failed calls to `nest()` do _not_ increment the scope's count of
+  outstanding operations.
 
-While a scope is closed or joined, calls to `nest(snd, scope.get_token())` will always fail by discarding the given
-sender and returning an unassociated _`nest-sender`_. Failed calls to `nest()` do not change the scope's count.
-Unassociated _`nest-senders`_ do not have a reference to the scope they came from and always complete with `stopped`
-when connected and started. Copying or moving an unassociated sender produces another unassociated sender.
+While a scope is open, calls to `nest()` that return normally will have incremented the scope's count of oustanding
+operations. In this case, the resulting _`nest-sender`_ is an associated sender that acts like an RAII handle: the
+scope's internal count is incremented when the sender is created and decremented when the sender is "done with the
+scope", which happens when the sender or its _`operation-state`_ is destroyed. Moving a _`nest-sender`_ transfers
+responsibility for decrementing the count from the old instance to the new one. Copying an associated _`nest-sender`_ is
+permitted if the sender it's wrapping is copyable, but the copy may "fail" since copying requires incrementing the
+scope's count, which is only allowed when the scope is open; if copying fails, the new sender is an unassociated sender
+that behaves as if it were the result of a failed call to `nest()`.
 
-The state transitions of a `counting_scope` mean that it can be used to protect asynchronous work from use-after-free
-errors. Given a resource, `res`, and a `counting_scope`, `scope`, obeying the following policy is enough to ensure that
-there are no attempts to use `res` after its lifetime ends:
-
-- all senders that refer to `res` are nested within `scope`; and
-- `scope` is destroyed (and therefore joined or unused) before `res` is destroyed.
-
-It is safe to destroy a scope in the unused state because there can't be any work referring to the resources protected
-by the scope.
-
-[comment]: # (TODO: The following paragraph is much less convincing after splitting scopes into scopes and tokens.)
+While a scope is closed, calls to `nest()` that return normally will have failed to increment the scope's count of
+outstanding operations or otherwise change the scope's state. In this case, the resulting _`nest-sender`_ is an
+unassociated sender. Unassociated _`nest-senders`_ do not have a reference to the scope they came from and always
+complete with `stopped` when connected and started. Copying or moving an unassociated sender produces another
+unassociated sender.
 
 Under the standard assumption that the arguments to `nest()` are and remain valid while evaluating `nest()`, it is
-always safe to invoke any supported operation on the returned _`nest-sender`_. Furthermore, if all senders returned from
-`nest()` are eventually started or discarded then the `join()` operation always eventually finishes because the number
-of outstanding senders nested within the corresponding scope is monotonically decreasing. Conversely, the `join()`
-operation will never terminate if there are any associated _`nest-senders`_ that never become "done with the scope"
-(i.e. that remain either unconnected or unstarted until after the `join()` is expected to complete). For example:
+always safe to invoke any supported operation on the returned _`nest-sender`_.
+
+The state transitions of a `simple_counting_scope` mean that it can be used to protect asynchronous work from
+use-after-free errors. Given a resource, `res`, and a `simple_counting_scope`, `scope`, obeying the following policy is
+enough to ensure that there are no attempts to use `res` after its lifetime ends:
+
+- all senders that refer to `res` are nested within `scope`; and
+- `scope` is destroyed (and therefore in the joined, unused, or unused-and-closed state) before `res` is destroyed.
+
+It is safe to destroy a scope in the unused or unusued-and-closed state because there can't be any work referring to the
+resources protected by the scope.
+
+A `simple_counting_scope` is uncopyable and immovable so its copy and move operators are explicitly deleted.
+`simple_counting_scope` could be made movable but it would cost an allocation so this is not proposed.
+
+### `simple_counting_scope::simple_counting_scope()`
 
 ```cpp
-void deadlock() {
-    namespace ex = std::execution;
-
-    ex::counting_scope scope;
-
-    ex::sender auto s = ex::nest(ex::just(), scope.get_token());
-
-    // never completes because s's continued existence keeps the scope open
-    std::this_thread::sync_wait(scope.join());
-}
+simple_counting_scope::simple_counting_scope() noexcept;
 ```
 
+Initializes a `simple_counting_scope` in the unused state with the count of outstanding operations set to zero.
 
-The risk of deadlock is explicitly preferred in this design over the risk of use-after-free errors because
-`counting_scope` is an async scope that is biased towards being used to progressively add structure to
-generally-unstructured code. We've found that the central problem in progressively structuring unstructured code is
-determining appropriate bounds for each asynchronous task when those bounds are not clear; it is easier to figure out
-where to synchronously `join()` a scope than it is to ensure that all `spawn()`ed work is properly scoped within any
-particular object's lifetime. So, although it is generally easier to diagnose use-after-free errors than it is to
-diagnose deadlocks, we've found that it's easier to *avoid* deadlocks with this design than it is to avoid
-use-after-free errors with other designs.
-
-A `counting_scope` is uncopyable and immovable so its copy and move operators are explicitly deleted. `counting_scope`
-could be made movable but it would cost an allocation so this is not proposed.
-
-### `counting_scope::counting_scope()`
+### `simple_counting_scope::~simple_counting_scope()`
 
 ```cpp
-counting_scope::counting_scope() noexcept;
+simple_counting_scope::~simple_counting_scope();
 ```
 
-Initializes a `counting_scope` in the unused state with no outstanding senders.
+Checks that the `simple_counting_scope` is in the joined, unused, or unused-and-closed state and invokes
+`std::terminate()` if not.
 
-### `counting_scope::~counting_scope()`
+### `simple_counting_scope::get_token()`
 
 ```cpp
-counting_scope::~counting_scope();
+simple_counting_scope::token get_token() noexcept;
 ```
 
-Checks that the `counting_scope` is in the joined or unused state and invokes `std::terminate()` if not.
+Returns a `simple_counting_scope::token` referring to the current scope, as if by invoking `token{this}`.
 
-### `counting_scope::get_token()`
-
-```cpp
-counting_scope::token get_token() noexcept;
-```
-
-Returns a `counting_scope::token` referring to the current scope, as if by invoking `token{this}`.
-
-### `counting_scope::join()`
+### `simple_counting_scope::join()`
 
 ```cpp
 struct @@_join-sender_@@; // @@_exposition-only_@@
@@ -1343,17 +1383,17 @@ struct @@_join-sender_@@; // @@_exposition-only_@@
 ```
 
 Returns a _`join-sender`_. When the _`join-sender`_ is connected to a receiver, `r`, it produces an
-_`operation-state`_, `o`. When `o` is started, the scope moves from either the unused or open state to the
-closed/joining state. `o` completes with `set_value()` when the scope moves from the closed/joining state to the closed
-state, which happens when the scope's count of outstanding senders drops to zero. `o` may complete synchronously if it
-happens to observe that the count of outstanding senders is already zero when started; otherwise, `o` completes on the
-execution context associated with the scheduler in its receiver's environment by asking its receiver, `r`, for a
-scheduler, `sch`, with `get_scheduler(get_env(r))` and then starting the sender returned from `schedule(sch)`. This
-requirement to complete on the receiver's scheduler restricts which receivers a _`join-sender`_ may be connected to in
-exchange for determinism; the alternative would have the _`join-sender`_ completing on the execution context of
-whichever nested operation happens to be the last one to complete.
+_`operation-state`_, `o`. When `o` is started, the scope moves to either the open-and-joining or closed-and-joining
+state. `o` completes with `set_value()` when the scope moves to the joined state, which happens when the scope's count
+of outstanding senders drops to zero. `o` may complete synchronously if it happens to observe that the count of
+outstanding senders is already zero when started; otherwise, `o` completes on the execution context associated with the
+scheduler in its receiver's environment by asking its receiver, `r`, for a scheduler, `sch`, with
+`get_scheduler(get_env(r))` and then starting the sender returned from `schedule(sch)`. This requirement to complete on
+the receiver's scheduler restricts which receivers a _`join-sender`_ may be connected to in exchange for determinism;
+the alternative would have the _`join-sender`_ completing on the execution context of whichever nested operation happens
+to be the last one to complete.
 
-### `counting_scope::token::nest()`
+### `simple_counting_scope::token::nest()`
 
 ```cpp
 template <sender S>
@@ -1364,26 +1404,21 @@ template <sender S>
         std::is_nothrow_constructible_v<std::remove_cvref_t<S>, S>);
 ```
 
-Attempts to atomically increments the scope's count of outstanding senders, which succeeds if and only if the scope is
-in the open or unused state, and then returns a _`nest-sender`_. When invoked successfully on a scope in the unused
-state, transitions the scope to the open state upon return unless, between the increment and the return, the state has
-concurrently transitioned to closed/joining.
+Attempts to return an associated _`nest-sender`_ constructed from `s`. The attempt will be successful if and only if:
 
-The result of `nest()` depends on whether the attempt to atomically increment the number of outstanding senders
-succeeds:
+- copying or moving (as appropriate) `s` into the _`nest-sender`_ does not throw an exception, and
+- the token's scope's state can be successfully updated as described below.
 
-- If the atomic increment succeeds then the return value will be an associated _`nest-sender`_ that contains a copy of
-  the input sender, `s` (that is copy- or move-constructed from `s`), and a reference to `scope_` (the associated
-  scope).  `nest()` provides the Strong Exception Guarantee, which requires one of two different behaviours upon
-  exiting from `nest()`, depending on whether the exit is normal or exceptional:
-  - if the scope was in the unused state, `nest()` returns normally, and the scope has not yet moved to the
-    closed/joining state then the scope moves to the open state; otherwise,
-  - if `nest()` exits with an exception (which is only possible if an exception is thrown while copying or moving `s`
-    into the returned _`nest-sender`_) then the increment to the scope's count of outstanding senders that happened on
-    entry to `nest()` is undone with a balancing decrement.
-- If the atomic increment fails then the return value will be an unassociated _`nest-sender`_ and no exceptions are
-  possible. In this case, the return value does not store a reference to `scope_`, the given sender, `s`, is discarded,
-  and the scope's state is left unchanged.
+If construction of the _`nest-sender`_ throws, the scope's state is left unchanged. Otherwise, the following atomic
+state change is attempted on the token's scope:
+
+- increment the scope's count of outstanding operations; and
+- move the scope to the open state if it was in the unused state.
+
+The atomic state change succeeds if the scope is observed to be in the unused, open, or open-and-joining state;
+otherwise it fails.
+
+If the atomic state change fails then the return value is an unassociated _`nest-sender`_.
 
 An associated _`nest-sender`_ is a kind of RAII handle to the scope; it is responsible for decrementing the scope's
 count of outstanding senders in its destructor unless that responsibility is first given to some other object.
@@ -1394,17 +1429,15 @@ sender, `s`, that was originally passed to `nest()`); it's expected that the chi
 effect of the _`nest-sender`_'s _`operation-state`_'s destructor.
 
 Note: the timing of when an _`operation-state`_ decrements the scope's count is chosen to avoid exposing user code to
-dangling references. Decrementing the scope's count may move the scope from the closed/joining state to the joined
-state, which would allow the waiting _`join-sender`_ to complete, potentially leading to the destruction of a resource
-protected by the scope. In general, it's possible that the _`nest-sender`_'s receiver or the child operation's
-destructor may dereference pointers to the protected resource so their execution must be completed before the scope
-moves to the joined state.
+dangling references. Decrementing the scope's count may move the scope to the joined state, which would allow the
+waiting _`join-sender`_ to complete, potentially leading to the destruction of a resource protected by the scope. In
+general, it's possible that the _`nest-sender`_'s receiver or the child operation's destructor may dereference pointers
+to the protected resource so their execution must be completed before the scope moves to the joined state.
 
-Whenever the balancing decrement happens (including if it happens as a side effect of allowing an exception to escape
-from `nest()`), it's possible that the scope has transitioned to the closed/joining state since the _`nest-sender`_ was
-constructed, which means that there is a _`join-sender`_ waiting to complete. If the decrement brings the count of
-outstanding senders to zero then the waiting _`join-sender`_ must be notified that the scope is now joined and the
-sender can complete.
+Whenever the balancing decrement happens, it's possible that the scope has transitioned to the open-and-joining or
+closed-and-joining state since the _`nest-sender`_ was constructed, which means that there is a _`join-sender`_ waiting
+to complete. If the decrement brings the count of outstanding operations to zero then the waiting _`join-sender`_ must
+be notified that the scope is now joined and the sender can complete.
 
 A call to `nest()` does not start the given sender. A call to `nest()` is not expected to incur allocations other than
 whatever might be required to move or copy `s`.
@@ -1416,7 +1449,7 @@ As `nest()` does not immediately start the given work, it is ok to pass in block
 
 Usage example:
 ```cpp
-sender auto example(counting_scope::token token, scheduler auto sched) {
+sender auto example(simple_counting_scope::token token, scheduler auto sched) {
   sender auto snd = nest(key_work(), token);
 
   for (int i = 0; i < 10; i++)


### PR DESCRIPTION
Incorporate feedback from the folks working on P2300 and make the following changes:
 - give `counting_scope` a `.close()` method, which makes `.join()` not responsible for closing the scope
 - give `counting_scope` an internal stop source and a public `request_stop()` method, like `unifex::v1::async_scope`
 - introduce `simple_counting_scope`, which is like `counting_scope` but without the stop source or the `.request_stop()` method

This first change only adds a call to `close()` in the rsys-based example and adds the new type and methods to section 5.1 Definitions; more change will come in this branch.