### PR TITLE
First pass at moving to try_associate()

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "wg21"]
 	path = wg21
-	url = https://github.com/kirkshoop/wg21.git
-	branch = addplantuml
+	url = https://github.com/ispeters/wg21.git
+	branch = add_contributor_section

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -1258,6 +1258,9 @@ struct simple_counting_scope {
     struct token {
      bool try_associate() const;
 
+     template <sender Sender>
+     Sender&& wrap(Sender&& s) noexcept;
+
      void dissociate() const;
 
      private:
@@ -1543,8 +1546,12 @@ struct counting_scope {
     counting_scope& operator=(const counting_scope&) = delete;
     counting_scope& operator=(counting_scope&&) = delete;
 
+    struct wrapper-sender; // @@_exposition-only_@@
+
     struct token {
       bool try_associate() const;
+
+      wrapper-sender wrap(sender auto&&);
 
       void dissociate() const;
 

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -1,6 +1,6 @@
 ---
 title: "`async_scope` -- Creating scopes for non-sequential concurrency"
-document: D3149R6
+document: P3149R6
 date: today
 audience:
   - "SG1 Parallelism and Concurrency"
@@ -1241,7 +1241,7 @@ resulting _`nest-sender`_ is also copyable, with the following rules:
   1. copy the association from the source into the destination _`nest-sender`_
      - if the copied association is engaged then copy the wrapped sender from the source into the destination
        _`nest-sender`_; the destination is associated
-     - otherwise, the destination is unassociate
+     - otherwise, the destination is unassociated
 
 When _`nest-sender`_ has a copy constructor, it provides the Strong Exception Guarantee.
 
@@ -1967,6 +1967,10 @@ connected receiver _and_ the stop source in the token's `counting_scope`.
 ```cpp
 async_scope_association auto try_associate() const;
 ```
+
+Returns an `async_scope_association` that is engaged if the token's scope is open, and disengaged if it's closed.
+`try_associate()` behaves as if its `counting_scope` owns a `simple_counting_scope`, `scope`, and the result is
+equivalent to the result of invoking `scope.get_token().try_associate()`.
 
 ## When to use `counting_scope` vs [@P3296R2]'s `let_async_scope`
 

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -997,15 +997,9 @@ iteract:
 template <sender Sender, async_scope_token Token>
 struct @@_nest-sender_@@ {
   @@_nest-sender_@@(Sender s, Token t)
-    : token_(t) {
-    if (token_.try_associate()) {
-      try {
-        sender_.emplace(token_.wrap(move(s)));
-      }
-      catch (...) {
-        token_.dissociate();
-        throw;
-      }
+    : token_(t), sender_(token_.wrap(move(s))) {
+    if (!token_.try_associate()) {
+      sender_.reset(); // assume no-throw destructor
     }
   }
 

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -1502,7 +1502,7 @@ void close() noexcept;
 ```
 
 Moves the scope to the closed, unused-and-closed, or closed-and-joining state. After a call to `close()`, all future
-calls to `nest()` that return normally return unassociated senders.
+calls to `try_associate()` return `false`.
 
 ### `simple_counting_scope::join`
 
@@ -1525,16 +1525,18 @@ to be the last one to complete.
 
 ### `simple_counting_scope::token::wrap`
 
-``cpp
-struct token {
-   template<sender Sender>
-   Sender&& wrap(Sender&&s) noexcept;
-}
+```cpp
+template <sender Sender>
+Sender&& wrap(Sender&& s) const noexcept;
 ```
 
-Returns the input sender, unmodified.
+Returns the input sender unmodified.
 
 ### `simple_counting_scope::token::try_associate`
+
+```cpp
+bool try_associate() const;
+```
 
 // TODO: Add explanation
 

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -1117,8 +1117,8 @@ void spawn(Sender&& snd, Token token, Env env = {});
 Attempts to associate the given sender with the given scope token's scope. On success, the given sender is eagerly
 started.  On failure, either the sender is discarded and no further work happens or `spawn()` throws.
 
-Starting the given sender involves a dynamic allocation of the sender's _`operation-state`_. The following algorithm
-determines which _Allocator_ to use for this allocation:
+Starting the given sender without waiting for it to finish requires a dynamic allocation of the sender's
+_`operation-state`_. The following algorithm determines which _Allocator_ to use for this allocation:
 
  - If `get_allocator(env)` is valid and returns an _Allocator_ then choose that _Allocator_.
  - Otherwise, if `get_allocator(get_env(snd))` is valid and returns an _Allocator_ then choose that _Allocator_.
@@ -1129,7 +1129,7 @@ determines which _Allocator_ to use for this allocation:
 1. `token.try_associate()` is invoked; if it returns `false`, `spawn()` returns
 2. an _`operation-state`_ is dynamically allocated by the _Allocator_ chosen as described above
 3. the _`operation-state`_ is initialized with the result of
-   `connect(token.wrap(forward<Sender>(sender)), @@_spawn-receiver_@@{})`
+   `connect(token.wrap(forward<Sender>(sender)), @@_spawn-receiver_@@{...})`
 4. the _`operation-state`_ is started
 
 Upon completion of the _`operation-state`_, the following steps happen in the following order:
@@ -1147,7 +1147,6 @@ work described by the sender. The `simple_counting_scope` and `counting_scope` d
 opportunity to keep a count of spawned senders that haven't finished, and to prevent new senders from being spawned
 once the scope has been closed.
 
-// TODO: this next paragraph is open for debate now
 The given sender must complete with `set_value()` or `set_stopped()` and may not complete with an error; the user must
 explicitly handle the errors that might appear as part of the _`sender-expression`_ passed to `spawn()`.
 
@@ -1163,7 +1162,6 @@ Usage example:
 for (int i = 0; i < 100; i++)
     spawn(on(sched, some_work(i)), scope.get_token());
 ```
-
 
 ## `execution::spawn_future`
 

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -934,7 +934,7 @@ An async scope token's implementation of the `async_scope_token` concept:
 
  - must allow an arbitrary sender to be wrapped without eagerly starting the sender;
  - must not add new value or error completions when wrapping a sender;
- - may fail to associate a new sender by returning an association that converts to `false` from `try_associate()`;
+ - may fail to associate a new sender by returning a disengaged association from `try_associate()`;
  - may fail to associate a new sender by eagerly throwing an exception from either `try_associate()` or `wrap()`;
 
 More on these items can be found below in the sections below.
@@ -1620,7 +1620,7 @@ state---the _`operation-state`_ must be started to effect the state change. A st
 scope's count of outstanding operations reaches zero, at which point the scope transitions to the joined state.
 
 Calling `close()` on a `simple_counting_scope` moves the scope to the closed, unused-and-closed, or closed-and-joining
-state, and causes all future calls to `try_associate()` to return `false`.
+state, and causes all future calls to `try_associate()` to return disengaged associations.
 
 Associating work with a `simple_counting_scope` can be done through `simple_counting_scope`'s token.
 `simple_counting_scope`'s token provides 2 methods: `wrap(Sender&& s)`, and `try_associate()`.
@@ -1686,7 +1686,7 @@ void close() noexcept;
 ```
 
 Moves the scope to the closed, unused-and-closed, or closed-and-joining state. After a call to `close()`, all future
-calls to `try_associate()` return `false`.
+calls to `try_associate()` return disengaged associations.
 
 ### `simple_counting_scope::join`
 


### PR DESCRIPTION
We updated much of section 5 to move from scope tokens having a `nest()` method to having a `try_associate() -> bool` method and a corresponding `dissociate() -> void()` method.

We discovered that there's no way to implement `counting_scope`'s "cancel all outstanding tasks" behaviour because there's no way to associate the sender with the scope's stop token.

We're contemplating `std::optional<sender auto> try_associate(sender auto&&)`. It'd be nice if `simple_counting_scope` could return an optional containing  reference to the provided sender to avoid unnecessary copies/moves; `counting_scope` needs to provide an optional containing a new sender value. Not sure if `std::optional<T&>` has made it into C++26, and, if it has, whether `std::optional<T&&>` is a thing.

There are several (~5?) TODOs added to the paper, too.