### PR TITLE
added the new components to [execution.syn]

### DIFF
--- a/asyncscope.md
+++ b/asyncscope.md
@@ -2336,13 +2336,11 @@ concept async_scope_association =
         { static_cast<bool>(assoc) } noexcept;
     };
 
-template <class Token, class Sender>
-concept async_scope_token_for =
+template <class Token>
+concept async_scope_token =
     copyable<Token> &&
-    sender<Sender> &&
-    requires(Token token, Sender&& snd) {
+    requires(Token token) {
         { token.try_associate() } -> async_scope_association;
-        { token.wrap(std::forward<Sender>(snd) } -> sender;
     };
 
 }

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -985,7 +985,7 @@ template <async_scope_token Token>
 using @@_association-from_@@ = decltype(declval<Token&>().try_associate()); // @@_exposition-only_@@
 
 template <async_scope_token Token, sender Sender>
-using @@_wrapped-sender-from_@@ = decay_t<decltype(declval<Token&>().wrap(declval<Sender>()))>; // @@_exposition-only_@
+using @@_wrapped-sender-from_@@ = decay_t<decltype(declval<Token&>().wrap(declval<Sender>()))>; // @@_exposition-only_@@
 
 template <sender Sender, async_scope_token Token>
 struct @@_nest-sender_@@ { // @@_exposition-only_@@
@@ -1006,7 +1006,7 @@ auto nest(Sender&& snd, Token token)
 template <sender Sender, async_scope_token Token, class Env = empty_env>
 void spawn(Sender&& snd, Token token, Env env = {})
     requires sender_to<decltype(token.wrap(forward<Sender>(snd))),
-                       @@_spawn-receiver_@@<End>>;
+                       @@_spawn-receiver_@@<Env>>;
 
 template <sender Sender, async_scope_token Token, class Env = empty_env>
 @@_future-sender-t_@@<Sender, Env> spawn_future(Sender&& snd, Token token, Env env = {});
@@ -2230,6 +2230,90 @@ alternatives: `complete()`, `close()`
 
 Specification
 ============
+
+## Header `<version>` synopsis [version.syn]{.sref}
+
+To the `<version>` synopsis [version.syn]{.sref}, add the following:
+
+```c++
+#define __cpp_lib_coroutine                         201902L // also in <coroutine>
+@[`#define __cpp_lib_counting_scope                    2025XXL // also in <execution>`]{.add}@
+#define __cpp_lib_debugging                         202403L // freestanding, also in <debugging>
+```
+
+## Header `<execution>` synopsis [execution.syn]{.sref}
+
+To the `<execution>` synopsis [execution.syn]{.sref}, add the following after
+the declaraiton of `run_loop`:
+
+> ```c++
+> ...
+> namespace std::execution {
+>   ...
+>   // [exec.run.loop], run_loop
+>   class run_loop;
+>
+> ```
+
+::: add
+
+> ```c++
+>   // [exec.scope.concepts], scope concepts
+>   template <class Assoc>
+>     concept async_scope_association = @_see below_@;
+>
+>   template <class Token>
+>     concept async_scope_token = @_see below_@;
+>
+>   // [exec.scope.expos]
+>   template <class Env>
+>     struct @_spawn-env_@; // @_exposition-only_@
+>
+>   template <class Env>
+>     struct @_spawn-receiver_@; // @_exposition-only_@
+>
+>   template <class Env>
+>     struct @_future-env_@; // @_exposition-only_@
+>
+>   template <@_valid-completion-signatures_@ Sig>
+>     struct @_future-sender_@; // @_exposition-only_@
+>
+>   template <sender Sender, class Env>
+>     using @_future-sender-t_@; // @_exposition-only_@
+>
+>   template <async_scope_token Token>
+>       using @_association-from_@ = decltype(declval<Token&>().try_associate()); // @_exposition-only_@
+>
+>   template <async_scope_token Token, sender Sender>
+>     using @_wrapped-sender-from_@ = decay_t<decltype(declval<Token&>().wrap(declval<Sender>()))>; // @_exposition-only_@
+>
+>   // [exec.scope.algos]
+>   template <sender Sender, async_scope_token Token>
+>     struct @_nest-sender_@; // @_exposition-only_@
+>
+>   template <sender Sender, async_scope_token Token>
+>     auto nest(Sender&& snd, Token token)
+>       noexcept(is_nothrow_constructible_v<@_nest-sender_@<Sender, Token>, Sender, Token>)
+>     -> @_nest-sender_@<Sender, Token>;
+>
+>   template <sender Sender, async_scope_token Token, class Env = empty_env>
+>     void spawn(Sender&& snd, Token token, Env env = {})
+>       requires sender_to<decltype(token.wrap(forward<Sender>(snd))), @_spawn-receiver_@<Env>>;
+>
+>   template <sender Sender, async_scope_token Token, class Env = empty_env>
+>     @_future-sender-t_@<Sender, Env> spawn_future(Sender&& snd, Token token, Env env = {});
+>
+>   // [exec.simple.counting.scope]
+>   class simple_counting_scope;
+>
+>   // [exec.counting.scope]
+>   class counting_scope;
+> ```
+:::
+
+> ```c++
+> }
+> ```
 
 ## Async scope concepts
 

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -2246,7 +2246,7 @@ To the `<version>` synopsis [version.syn]{.sref}, add the following:
 To the `<execution>` synopsis [execution.syn]{.sref}, add the following after
 the declaraiton of `run_loop`:
 
-> ```c++
+> ```
 > ...
 > namespace std::execution {
 >   ...
@@ -2311,7 +2311,7 @@ the declaraiton of `run_loop`:
 > ```
 :::
 
-> ```c++
+> ```
 > }
 > ```
 
@@ -2320,10 +2320,12 @@ the declaraiton of `run_loop`:
 Add the following as a new subsection immediately after __[exec.utils.tfxcmplsigs]__:
 
 ::: add
-__`std::execution::async_scope_association` [exec.asyncscopeassociation.concept]__
+__Scope concepts [exec.scope.concepts]__
 
 [1]{.pnum} The `async_scope_association<Assoc>` concept defines the requirements on an object of type `Assoc` that
 represents a possible assocation with an async scope object.
+The `async_scope_token<Token>` concept defines the requirements on an object of type `Token` that can
+be used to create associations between senders and an async scope.
 ```cpp
 namespace std::execution {
 
@@ -2333,31 +2335,25 @@ concept async_scope_association =
     requires(const Assoc& assoc) {
         { static_cast<bool>(assoc) } noexcept;
     };
+
+template <class Token, class Sender>
+concept async_scope_token_for =
+    copyable<Token> &&
+    sender<Sender> &&
+    requires(Token token, Sender&& snd) {
+        { token.try_associate() } -> async_scope_association;
+        { token.wrap(std::forward<Sender>(snd) } -> sender;
+    };
+
 }
 ```
 [2]{.pnum} `async_scope_association<Assoc>` is modeled only if `Assoc`'s copy and move operations are not potentially
 throwing.
 
-__`std::execution::async_scope_token` [exec.asyncscopetoken.concept]__
-
-[1]{.pnum} The `async_scope_token<Token>` concept defines the requirements on an object of type `Token` that can
-be used to create associations between senders and an async scope.
-```cpp
-namespace std::execution {
-
-template <class Token>
-concept async_scope_token =
-    copyable<Token> &&
-    requires(Token token) {
-        { token.try_associate() } -> async_scope_association;
-    } &&
-
-}
-```
-[2]{.pnum} `async_scope_token<Token>` is modeled only if `Token`'s copy and move operations are not potentially
+[3]{.pnum} `async_scope_token<Token>` is modeled only if `Token`'s copy and move operations are not potentially
 throwing.
 
-[3]{.pnum} For a subexpression `snd`, let `Sndr` be `decltype((snd))` and let `sender<Sndr>` be true;
+[4]{.pnum} For a subexpression `snd`, let `Sndr` be `decltype((snd))` and let `sender<Sndr>` be true;
 `async_scope_token<Token>` is modeled only if, for an object, `token`, of type `Token`, the expression
 `token.wrap(snd)` is a valid expression and returns an object that satisfies `sender`.
 :::

--- a/asyncscope.md
+++ b/asyncscope.md
@@ -2244,7 +2244,7 @@ To the `<version>` synopsis [version.syn]{.sref}, add the following:
 ## Header `<execution>` synopsis [execution.syn]{.sref}
 
 To the `<execution>` synopsis [execution.syn]{.sref}, add the following after
-the declaraiton of `run_loop`:
+the declaration of `run_loop`:
 
 > ```
 > ...


### PR DESCRIPTION
The current text isn't quite consistent as the synopsis references `[exec.scope.concepts]` but the two concepts have their own section. Let me know which direction to go and I'll adjust. Likewise `nest` has its own section but that isn't quite reflected in the synopsis.

I _think_ for the algorithms the specification should be consistent and use CPOs for `nest`, `spawn`, and `spawn_future`. Currently, the change isn't made, yet. If there is agreement that this is the way to go, I'll also make that change.

I also spotted a few typos in the original text which are fixed.